### PR TITLE
Short-term fix for bug 'Tilde changes file ownership on save #28'

### DIFF
--- a/src/filebuffer.cc
+++ b/src/filebuffer.cc
@@ -291,7 +291,8 @@ rw_result_t file_buffer_t::save(save_as_process_t *state) {
              directly. The latter has some risk (e.g. file truncation due to full disk,
              or corruption due to computer crashes), but these are so small that it is
              worth permitting this if we can't create the temporary file. */
-          if ((state->fd = mkstemp(temp_name.data())) >= 0) {
+          if (geteuid() == state->file_info.st_uid
+              && (state->fd = mkstemp(temp_name.data())) >= 0) {
             state->temp_name = temp_name.data();
 // Preserve ownership and attributes
 #ifdef HAS_LIBATTR


### PR DESCRIPTION
For safety tilde prefers to double buffering file saves by creating a new temp file, then deleting the original file, then renaming the new file to the correct name. However this method changes the file owner to the current user writing the file.  So now tilde skips the double buffer method if, and only if, the current user writing the file is not the owner of the file.  It does a direct overwrite of the file instead.  This is more risk of losing the file, but it does not change the file owner.