### PR TITLE
docs: clarify build dependencies for Debian 12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ follow the steps below to build Tilde from the git repositories:
    * libacl1-dev
    * libattr1-dev
    * libgpm-dev
-   * libncurses5-dev
+   * libncurses-dev (called `libncurses5-dev` on older distributions)
    * libpcre2-dev
    * libtool-bin
    * libunistring-dev
    * libxcb1-dev and/or libx11-dev
    * pkg-config
-   * LLnextgen (available [here](https://os.ghalkes.nl/LLnextgen/download.html))
+   * LLnextgen — download the `.deb` package from the
+     [download page](https://os.ghalkes.nl/LLnextgen/download.html) and install
+     it with `sudo apt install ./llnextgen_*.deb`
    * clang (unless building using COMPILER=gcc)
 2. Clone the repositories:
 ```bash


### PR DESCRIPTION
Fixes #118

Two small clarifications to the "Developing Tilde" build steps, based on
problems reported by users building on Debian 12 (Bookworm) and Debian 13
(Trixie):

**`libncurses-dev` package name**

The package was renamed from `libncurses5-dev` to `libncurses-dev` in
Debian 12. The old name still works as a transitional package on Bookworm
but may not be present on future releases. Updated the list to use the
current name, with a note that older distributions use `libncurses5-dev`.

**LLnextgen install step**

Several users were confused by the "available here" link for LLnextgen —
it was not clear that you need to download a `.deb` and install it with
`apt`. Added the explicit `sudo apt install ./llnextgen_*.deb` command.